### PR TITLE
add hr secondary queue

### DIFF
--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -39,7 +39,8 @@ queue_timeout = {
 	'rms_push_queue':1500,
 	'so_primary':300,
 	'so_secondary':300,
-	'hr_primary':500
+	'hr_primary':500,
+	'hr_secondary':500,
 }
 
 redis_connection = None


### PR DESCRIPTION
**Modified frappe/frappe/utils/background_jobs.py:** Add hr_secondary queue.
**Note: Before going to live this on UAT and Prod add theses in supervisor config file.**

```
[program:frappe-bench-frappe-hr_secondary]
command=/usr/local/bin/bench worker --queue hr_primary
priority=4
autostart=true
autorestart=true
stdout_logfile=/home/frappe-user/frappe_bench/logs/worker.log
stderr_logfile=/home/frappe-user/frappe_bench/logs/worker.error.log
user=frappe-user
stopwaitsecs=1560
directory=/home/frappe-user/frappe_bench
killasgroup=true
numprocs=1
process_name=%(program_name)s-%(process_num)d
```

add `frappe-bench-frappe-hr_secondary` to
[group:frappe-bench-workers]
`frappe-bench-frappe-hr_secondary`

Restart Supervisorctl